### PR TITLE
Fix size comparison in caching allocator

### DIFF
--- a/2018_CppCon/src/coro_infra.h
+++ b/2018_CppCon/src/coro_infra.h
@@ -75,7 +75,7 @@ struct tcalloc {
   }
 
   void *alloc(size_t sz) {
-    if (root && root->size <= sz) {
+    if (root && root->size >= sz) {
       void *mem = root;
       root = root->next;
       return mem;


### PR DESCRIPTION
I think it supposed to reuse allocated storage if the requested size is less than or equal too previously released memory.